### PR TITLE
defaulting to standard plackup if none is found in PATH

### DIFF
--- a/t/test.t
+++ b/t/test.t
@@ -15,8 +15,8 @@ BEGIN {
     use File::Which;
 
     $perl = $Config{perlpath};
-    $plackup = which('plackup');
-    $ENV{'UBIC_SERVICE_PLACKUP_BIN'} = "$perl $plackup";
+    $plackup = which('plackup') || '';
+    $ENV{'UBIC_SERVICE_PLACKUP_BIN'} = "$perl $plackup" if $plackup;
 }
 
 system('rm -rf tfiles') and die "Can't remove tfiles: $!";


### PR DESCRIPTION
Hi!

First of all, thank you so much for all the work you put onto this module! I was looking at a way to help and noticed [some failing tests](http://www.cpantesters.org/distro/U/Ubic-Service-Plack.html?oncpan=1&distmat=1&version=1.18&grade=3), and it looks like most of them are related to `plackup` not being found by File::Which.

This may be related to the fact that File::Which looks for it under the `PATH` environment variable, and I think in some cases (such as while smoke testing or an environment where installed perl binaries are simply not directly put in the PATH) it just doesn't find it, even with Plack installed.

A simple (ish) solution is to, instead of actually running the external 'plackup' command, we replace it by its internals, turning the command into:

```perl
use Plack::Runner; my $r = Plack::Runner->new; $r->parse_options(@ARGV); $r->run;
```

The problem with this approach is Ubic::Daemon's `start_daemon` expecting a binary, not a function (and as I understand you don't want to support function running anymore).

So we could fiddle with the `UBIC_SERVICE_PLACKUP_BIN` environment variable and have it turn the `$plackup_command` variable into something like `[ 'perl', '-e', 'use Plack::Runner....']` and put the rest of the args from `sub bin` inside. But since that implied completely changing `UBIC_SERVICE_PLACKUP_BIN` I figured I should wait for your "ok" before sending any patches :)

What this PR does instead is simply ignore the cases where File::Which fails to find `plackup` and fallback to the default 'plackup' command. Please note that **tests will still fail** because this doesn't really fix anything, it just makes the error message clearer.

Even if you like this approach, please don't merge this just yet. There is another PR coming up with a different approach to the same issue, which I think you'll like more (and will most definitely be more useful).

Cheers!