### PR TITLE
bailout on missing 'plackup'

### DIFF
--- a/t/test.t
+++ b/t/test.t
@@ -14,9 +14,19 @@ BEGIN {
     use Config;
     use File::Which;
 
-    $perl = $Config{perlpath};
-    $plackup = which('plackup');
-    $ENV{'UBIC_SERVICE_PLACKUP_BIN'} = "$perl $plackup";
+    if (exists $ENV{'UBIC_SERVICE_PLACKUP_BIN'}) {
+        $plackup = $ENV{'UBIC_SERVICE_PLACKUP_BIN'};
+    }
+    else {
+        $perl = $Config{perlpath};
+        $plackup = which('plackup')
+            or BAIL_OUT(
+                 "Cannot find plackup binary in your PATH ($ENV{PATH}).\n"
+               . 'Please set it under the UBIC_SERVICE_PLACKUP_BIN environment variable.'
+               . ' Aborting...'
+            );
+        $ENV{'UBIC_SERVICE_PLACKUP_BIN'} = "$perl $plackup";
+    }
 }
 
 system('rm -rf tfiles') and die "Can't remove tfiles: $!";
@@ -76,7 +86,7 @@ use Ubic::Service::Plack;
 
     is_deeply(
         [ sort @{ $service->bin }],
-        [ sort($perl, $plackup, '--server', 'Starman', '-M', 'Foo', '-M', 'Bar', '--port', 1234, 't/bin/test.psgi') ],
+        [ sort(($perl || ()), $plackup, '--server', 'Starman', '-M', 'Foo', '-M', 'Bar', '--port', 1234, 't/bin/test.psgi') ],
         'bin generated correctly'
     );
 }


### PR DESCRIPTION
Hello! Me again :)

As promised, this is an alternative approach to #6. What I did here was bail out of the tests if no `plackup` binary is found by File::Which (instead of what I did in #6 which is defaulting to `"plackup"` which most likely will still fail).

While the issue itself is still not fixed (I don't think finding 'plackup' is the proper solution and I think we instead should use Plack::Runner directly, even via `perl -e`, as per the discussion in #6), the failing tests will do so with a much more informative message, including a dump of the PATH environment variable and extra information on how to fix the issue (in case it's a human and not a smoking box) by setting the environment properly.

It also fixes an ongoing issue where `UBIC_SERVICE_PLACKUP_BIN` was always being replaced during testing, so the only way to make tests pass would be to actually change the PATH to include the parent dir for `plackup` (wherever it was). Now the user can simply set `UBIC_SERVICE_PLACKUP_BIN` and the tests will find it!

I think this approach is better than the one in #6. If you agree, feel free to merge this and close the other. Otherwise, let me know if there's anything I can do to help :)

Cheers!
