### PR TITLE
Issue #9: enable server_args to handle boolean options correctly, e.g. enable-ssl

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Ubic-Service-Plack
 
 {{$NEXT}}
 
+	* rt 118052/Issue 9 - enable server_args to handle boolean options correctly, e.g. enable-ssl
+
 1.18    2014-08-03
         * bugfix - check Ubic::Daemon's version instead of Ubic's.
 

--- a/lib/Ubic/Service/Plack.pm
+++ b/lib/Ubic/Service/Plack.pm
@@ -205,14 +205,23 @@ sub bin {
         my $cmd_key = (length $key == 1) ? '-' : '--';
         $cmd_key .= $key;
         my $v = $args{$key};
-        next unless defined $v;
         if (ref $v eq 'ARRAY') {
             for my $value (@$v) {
-                push @cmd, $cmd_key, $value;
+                if (defined $value) {
+                    push @cmd, $cmd_key, $value;
+                }
+                else {
+                    push @cmd, $cmd_key;
+                }
             }
         }
         else {
-            push @cmd, $cmd_key, $v;
+            if (defined $v) {
+                push @cmd, $cmd_key, $v;
+            }
+            else {
+                push @cmd, $cmd_key;
+            }
         }
     }
     push @cmd, $self->{app};


### PR DESCRIPTION
# Testing

1. Manually applying patch allows me to start my apps under SSL (i.e https:// works) ✼
2. `prove -w t` == `All tests successful.`
3. https://github.com/throughnothing/Ubic-Service-Starman/issues/4 is about testing enable-ssl specifically

✼
```
return Ubic::Service::Starman->new(
    {
        server_args => {    # do not daemonize
            workers => 10,
            "enable-ssl" => undef,
            "ssl-cert"   => "$app_path/ssl/crt.crt",   # letsencrypt.org FTW!
            "ssl-key"    => "$app_path/ssl/key.key",
```